### PR TITLE
Removing href.li

### DIFF
--- a/PULL_REQUESTS/domains.txt
+++ b/PULL_REQUESTS/domains.txt
@@ -2036,7 +2036,6 @@ howopen.ru
 hplaserjetpdriver8y.pen.io
 hptwaakw.blog.fc2.com
 hreade.com
-href.li
 hscsscotland.com
 hspline.com
 htmlcorner.com


### PR DESCRIPTION
href.li is a redirection site by Automattic (the makers of WordPress.com) that was meant for our internal use to hide referral information when used on internal sites (e.g. so logs would have href.li as the referral vs private-site-url.example.com).

No content is actually hosted on this domain.