### PR TITLE
remove nsatc.net

### DIFF
--- a/hosts
+++ b/hosts
@@ -7208,7 +7208,6 @@
 0.0.0.0 ns2.kobatochan.co
 0.0.0.0 ns3.kobatochan.co
 0.0.0.0 ns3.ticbeat.co
-0.0.0.0 nsatc.net
 0.0.0.0 nsfree.org
 0.0.0.0 ns.kobatochan.co
 0.0.0.0 ns.ticbeat.co


### PR DESCRIPTION
nsatc.net appears to be a valid CDN and hosts a number of websites including Windows Update and login.microsoftonline.com.