### PR TITLE
Domain spb.ru is false positive.

### DIFF
--- a/PULL_REQUESTS/domains.txt
+++ b/PULL_REQUESTS/domains.txt
@@ -9454,7 +9454,6 @@ spasswelt.net
 spasswelt.xyz
 spbchampionat.ru
 spb-plitka.ru
-spb.ru
 spc-maker.com
 specialfinanceoffers.com
 special-porn.com


### PR DESCRIPTION
It is second level geodomain for Saint-Petersburg city (spb) in
Russian Federation. There are many government and other legal
third-level subdomains.

See more: https://en.wikipedia.org/wiki/.ru