### PR TITLE
remove insomniagamingfestival.com

### DIFF
--- a/PULL_REQUESTS/domains.txt
+++ b/PULL_REQUESTS/domains.txt
@@ -1294,7 +1294,6 @@ index.buckshost.com
 indiakino.net
 indiana.phone.directory.sms13.de
 inleadership.co.nz
-insomniagamingfestival.com
 insomniatguide.com
 instaflow.eu
 instagram-nameservers.com


### PR DESCRIPTION
Website for a large gaming festival in the UK